### PR TITLE
Bumped taxjar ruby to ~> 2.1.0

### DIFF
--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -2,13 +2,14 @@ module Spree
   module Admin
     class TaxjarSettingsController < Spree::Admin::BaseController
       def edit
-        @preferences_api = [:taxjar_api_key, :taxjar_enabled, :taxjar_debug_enabled]
+        @preferences_api = %i[taxjar_api_key taxjar_enabled taxjar_debug_enabled taxjar_sandbox_environment_enabled]
       end
 
       def update
         Spree::Config[:taxjar_api_key] = params[:taxjar_api_key]
         Spree::Config[:taxjar_enabled] = params[:taxjar_enabled]
         Spree::Config[:taxjar_debug_enabled] = params[:taxjar_debug_enabled]
+        Spree::Config[:taxjar_sandbox_environment_enabled] = params[:taxjar_sandbox_environment_enabled]
 
         flash[:success] = Spree.t(:taxjar_settings_updated)
         redirect_to edit_admin_taxjar_settings_path

--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -6,7 +6,7 @@ module Spree
       @order = order
       @shipment = shipment
       @reimbursement = reimbursement
-      @client = ::Taxjar::Client.new(api_key: Spree::Config[:taxjar_api_key])
+      @client = ::Taxjar::Client.new(client_params)
     end
 
     def create_refund_transaction_for_order
@@ -213,6 +213,15 @@ module Spree
         adjustments.select { |adjustment| adjustment.source_type != Spree::TaxRate.to_s }.map(&:amount).sum.to_f
       end
 
+      def client_params
+        {
+          api_key: Spree::Config[:taxjar_api_key],
+          api_url: api_url
+        }
+      end
 
+      def api_url
+        Spree::Config[:taxjar_sandbox_environment_enabled] ? ::Taxjar::API::Request::SANDBOX_API_URL : ::Taxjar::API::Request::DEFAULT_API_URL
+      end
   end
 end

--- a/config/initializers/app_configuration.rb
+++ b/config/initializers/app_configuration.rb
@@ -2,4 +2,5 @@ Spree::AppConfiguration.class_eval do
   preference :taxjar_api_key, :string
   preference :taxjar_enabled, :boolean, default: false
   preference :taxjar_debug_enabled, :boolean, default: false
+  preference :taxjar_sandbox_environment_enabled, :boolean, default: false
 end

--- a/spec/models/spree/taxjar_spec.rb
+++ b/spec/models/spree/taxjar_spec.rb
@@ -55,7 +55,7 @@ describe Spree::Taxjar do
   context 'When reimbursement is not present' do
     before :each do
       Spree::Config[:taxjar_api_key] = '04d828b7374896d7867b03289ea20957'
-      allow(::Taxjar::Client).to receive(:new).with(api_key: Spree::Config[:taxjar_api_key]).and_return(client)
+      allow(::Taxjar::Client).to receive(:new).with(api_key: Spree::Config[:taxjar_api_key], api_url: ::Taxjar::API::Request::DEFAULT_API_URL).and_return(client)
     end
 
     let(:spree_taxjar) { Spree::Taxjar.new(order) }
@@ -88,7 +88,7 @@ describe Spree::Taxjar do
 
       context 'when has_nexus? returns true' do
         before do
-          allow(::Taxjar::Client).to receive(:new).with(api_key: Spree::Config[:taxjar_api_key]).and_return(client)
+          allow(::Taxjar::Client).to receive(:new).with(api_key: Spree::Config[:taxjar_api_key], api_url: ::Taxjar::API::Request::DEFAULT_API_URL).and_return(client)
           allow(spree_taxjar).to receive(:has_nexus?).and_return(true)
           allow(client).to receive(:create_order).and_return(true)
         end
@@ -160,7 +160,7 @@ describe Spree::Taxjar do
   context 'When reimbursement is present' do
     let(:spree_taxjar) { Spree::Taxjar.new(order, reimbursement) }
     before do
-      allow(::Taxjar::Client).to receive(:new).with(api_key: Spree::Config[:taxjar_api_key]).and_return(client)
+      allow(::Taxjar::Client).to receive(:new).with(api_key: Spree::Config[:taxjar_api_key], api_url: ::Taxjar::API::Request::DEFAULT_API_URL).and_return(client)
     end
 
     describe '#create_refund_transaction_for_order' do

--- a/spree_taxjar.gemspec
+++ b/spree_taxjar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   spree_version = '>= 3.2.0', '<= 4.2.0'
 
   s.add_dependency 'spree_backend', spree_version
-  s.add_dependency 'taxjar-ruby', '~> 2.0.0'
+  s.add_dependency 'taxjar-ruby', '~> 2.1.0'
 
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails', '~> 4.2.1'


### PR DESCRIPTION
It would be great to lock `taxjar-ruby` version to 2.1 that introduced TaxJar sandbox API support
https://github.com/taxjar/taxjar-ruby/compare/v2.0.0...v2.1.0

