### PR TITLE
Bumped taxjar-ruby

### DIFF
--- a/spree_taxjar.gemspec
+++ b/spree_taxjar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   spree_version = '>= 3.2.0', '<= 4.2.0'
 
   s.add_dependency 'spree_backend', spree_version
-  s.add_dependency 'taxjar-ruby', '~> 2.1.0'
+  s.add_dependency 'taxjar-ruby', '~> 2.6.0'
 
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails', '~> 4.2.1'


### PR DESCRIPTION
This `taxjar-ruby` version supports TaxJar Plus API address validation 