### PR TITLE
Set default taxjar-ruby client timeout settings via spree initializer

### DIFF
--- a/config/initializers/app_configuration.rb
+++ b/config/initializers/app_configuration.rb
@@ -3,4 +3,5 @@ Spree::AppConfiguration.class_eval do
   preference :taxjar_enabled, :boolean, default: false
   preference :taxjar_debug_enabled, :boolean, default: false
   preference :taxjar_sandbox_environment_enabled, :boolean, default: false
+  preference :taxjar_timeout, :float
 end

--- a/config/initializers/app_configuration.rb
+++ b/config/initializers/app_configuration.rb
@@ -3,5 +3,5 @@ Spree::AppConfiguration.class_eval do
   preference :taxjar_enabled, :boolean, default: false
   preference :taxjar_debug_enabled, :boolean, default: false
   preference :taxjar_sandbox_environment_enabled, :boolean, default: false
-  preference :taxjar_timeout, :float
+  preference :taxjar_timeout, :float, default: 2.0
 end

--- a/lib/spree_taxjar/engine.rb
+++ b/lib/spree_taxjar/engine.rb
@@ -17,6 +17,10 @@ module SpreeTaxjar
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+
+      Dir.glob(File.join(File.dirname(__FILE__), '../../lib/taxjar/**/*_decorator*.rb')) do |c|
+        Rails.application.config.cache_classes ? require(c) : load(c)
+      end
     end
 
     initializer 'spree.register.calculators' do |app|

--- a/lib/taxjar/api/request_decorator.rb
+++ b/lib/taxjar/api/request_decorator.rb
@@ -1,0 +1,15 @@
+module Taxjar
+  module API
+    module RequestDecorator
+      def set_http_timeout
+        @http_timeout = {}
+
+        %i[connect write read].each do |method|
+          @http_timeout[method] = @options[:timeout] || ::Spree::Config[:taxjar_timeout]
+        end
+      end
+    end
+  end
+end
+
+Taxjar::API::Request.prepend Taxjar::API::RequestDecorator


### PR DESCRIPTION
https://github.com/taxjar/taxjar-ruby/blob/v2.6.1/lib/taxjar/api/request.rb#L55 override